### PR TITLE
Netlify tweaks for RSS feed

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/feed /feed.xml

--- a/config.toml
+++ b/config.toml
@@ -61,5 +61,4 @@ title = "lubieniebieski by adam nowak"
 
 [outputFormats]
   [outputFormats.RSS]
-    mediatype = "application/rss+xml"
     baseName = "feed"


### PR DESCRIPTION
on Github Pages `/feed` automatically redirects to `/feed.xml`, but on Netlify it doesn't.
Reeder sees `/feed` and `/feed.xml` as proper feeds on the blog (only `/feed.xml` should remain)